### PR TITLE
Fix loosing text between links

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function toSlack (jiraMD) {
     .replace(/\[([^|]+)\]/g, '<$1>')
 
     // Named Links
-    .replace(/\[(.+?)\|(.+)\]/g, '<$2|$1>')
+    .replace(/\[([^[\]|]+?)\|([^[\]|]+?)\]/g, '<$2|$1>')
 
     // Single Paragraph Blockquote
     .replace(/^bq\.\s+/gm, '> ')


### PR DESCRIPTION
Hi! This is fix for next case:

```
[link1|http://example.com] important text [link2|http://example.com]
```

Without this changes it transforms to 
```
<http://example.com] important text [link2|http://example.com|link1>
```