### PR TITLE
Updated the unnamed link regex to be a bit more strict

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function toSlack (jiraMD) {
     .replace(/{noformat}/g, '```')
 
     // Un-named Links
-    .replace(/\[([^|]+)\]/g, '<$1>')
+    .replace(/\[([^|{}\\^~[\]\s<>#%"`]+\.[^|{}\\^~[\]\s<>#%"`]+)\]/g, '<$1>')
 
     // Named Links
     .replace(/\[([^[\]|]+?)\|([^[\]|]+?)\]/g, '<$2|$1>')

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function toSlack (jiraMD) {
     .replace(/{noformat}/g, '```')
 
     // Un-named Links
-    .replace(/\[([^|{}\\^~[\]\s<>#%"`]+\.[^|{}\\^~[\]\s<>#%"`]+)\]/g, '<$1>')
+    .replace(/\[([^|{}\\^~[\]\s"`]+\.[^|{}\\^~[\]\s"`]+)\]/g, '<$1>')
 
     // Named Links
     .replace(/\[([^[\]|]+?)\|([^[\]|]+?)\]/g, '<$2|$1>')

--- a/test.js
+++ b/test.js
@@ -160,6 +160,12 @@ test('JIRA to Slack: Check Individual Formatting', (assert) => {
   );
 
   assert.equal(
+    J2S.toSlack('[] checkbox 1\n[] checkbox 2\n[this is just a comment]\nvar foo = ["1","2","3"]; var=[1,2,3]'),
+    '[] checkbox 1\n[] checkbox 2\n[this is just a comment]\nvar foo = ["1","2","3"]; var=[1,2,3]',
+    'Non-URL links'
+  );
+
+  assert.equal(
     J2S.toSlack('Blockquote: \nbq. This is quoted\n'),
     'Blockquote: \n> This is quoted\n',
     'Blockquote'


### PR DESCRIPTION
The link regex as it existed could pick up some false positive links.
This code attempts to make the regex a bit more strict such that
the text inside square brackets must include at least 1 dot and
should not include any characters that are not allowed in URLs

I included a test to illustrate the types of scenarios that will
now be ignored. 