### PR TITLE
Updated monospace regex to handle curly braces within code.

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function toSlack (jiraMD) {
     .replace(/_(\s*)(\S.*?\S)(\s*)_/g, '$1_$2_$3')
 
     // Monospaced text
-    .replace(/\{\{([^}]+)\}\}/g, '`$1`')
+    .replace(/\{\{(.+?)\}\}/g, '`$1`')
 
     // Citations
     .replace(/\?\?([^??]+)\?\?/g, '_-- $1_')

--- a/test.js
+++ b/test.js
@@ -75,8 +75,8 @@ test('JIRA to Slack: Check Individual Formatting', (assert) => {
   );
 
   assert.equal(
-    J2S.toSlack('Monospace: {{$code}}\n'),
-    'Monospace: `$code`\n',
+    J2S.toSlack('Monospace: {{$code with nested {singleCurlyBrace} }}\n'),
+    'Monospace: `$code with nested {singleCurlyBrace} `\n',
     'Monospace'
   );
 
@@ -204,7 +204,7 @@ test('JIRA to Slack: Check All Formatting', (assert) => {
     'Bold (spaced): * boldy is spaced *\n' +
     'Italic: _italicy_\n' +
     'Italic (spaced): _italicy is poorly spaced _\n' +
-    'Monospace: {{$code}}\n' +
+    'Monospace: {{$code with nested {singleCurlyBrace} }}\n' +
     'Citations: ??citation??\n' +
     'Subscript: ~subscript~\n' +
     'Superscript: ^superscript^\n' +
@@ -238,7 +238,7 @@ test('JIRA to Slack: Check All Formatting', (assert) => {
     'Bold (spaced):  *boldy is spaced* \n' +
     'Italic: _italicy_\n' +
     'Italic (spaced): _italicy is poorly spaced_ \n' +
-    'Monospace: `$code`\n' +
+    'Monospace: `$code with nested {singleCurlyBrace} `\n' +
     'Citations: _-- citation_\n' +
     'Subscript: _subscript\n' +
     'Superscript: ^superscript\n' +


### PR DESCRIPTION
The Jira to Slack conversion would break if the Jira monospace text block included some curly braces. For example, {{PUT /rest/api/2/issue/{issueIdOrKey}/assignee}} which should convert to `PUT /rest/api/2/issue/{issueIdOrKey}/assignee`. This update to the regex allows it to match monospace block that contains curly braces.