### PR TITLE
Fix issue with greedy regex for color formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ function toSlack (jiraMD) {
     .replace(/^bq\.\s+/gm, '> ')
 
     // Remove color: unsupported in md
-    .replace(/\{color:[^}]+\}([^]*)\{color\}/gm, '$1')
+    .replace(/\{color:[^}]+\}([^]*?)\{color\}/gm, '$1')
 
     // panel into table
     .replace(/\{panel:title=([^}]*)\}\n?([^]*?)\n?\{panel\}/gm, '\n| $1 |\n| --- |\n| $2 |')

--- a/test.js
+++ b/test.js
@@ -219,6 +219,7 @@ test('JIRA to Slack: Check All Formatting', (assert) => {
     'Multiple Links: [Someurl1|http://someurl1.com] links to [Someurl2|http://someurl2.com]\n' +
     'Blockquote: \nbq. This is quoted\n' +
     'Color: {color:white}This is white text{color}\n' +
+    'Multiple Colors: {color:white}This is white text{color} {color:black}This is black text{color}\n' +
     'Panel: {panel:title=foo}Panel Contents{panel}\n';
 
   const expectedText = '\n *Heading*\n\nFoo foo _foo_ foo foo foo\n' +
@@ -253,6 +254,7 @@ test('JIRA to Slack: Check All Formatting', (assert) => {
     'Multiple Links: <http://someurl1.com|Someurl1> links to <http://someurl2.com|Someurl2>\n' +
     'Blockquote: \n> This is quoted\n' +
     'Color: This is white text\n' +
+    'Multiple Colors: This is white text This is black text\n' +
     'Panel: \n| foo |\n| --- |\n| Panel Contents |\n';
 
   const response = J2S.toSlack(jiraFormat);


### PR DESCRIPTION
When removing the {color} tags from Jira input the regex was greedy,
thus if multiple {color} tags are included in the input only the
opening {color:foo} and final closing {color} tags will be removed.
This is illustrated in input like:

{color:white}this is white{color} {color:black}this is black{color}

In this case the output would be:

this is white{color} {color:black}this is black

This change makes the intermediary part of the regex [^]* into a
non-greedy search [^]*? which will stop at the first {color} it finds

Test included to illustrate and validate this change