### PR TITLE
Added smart link detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,9 @@ function toSlack (jiraMD) {
     // Named Links
     .replace(/\[([^[\]|]+?)\|([^[\]|]+?)\]/g, '<$2|$1>')
 
+    // Smart Links
+    .replace(/\[([^[\]|]+?)\|([^[\]|]+?)\|(smart-link)\]/g, '<$1>')
+
     // Single Paragraph Blockquote
     .replace(/^bq\.\s+/gm, '> ')
 

--- a/test.js
+++ b/test.js
@@ -154,6 +154,12 @@ test('JIRA to Slack: Check Individual Formatting', (assert) => {
   );
 
   assert.equal(
+    J2S.toSlack('Smart Link: [http://someurl.com|http://someurl.com|smart-link]\n'),
+    'Smart Link: <http://someurl.com>\n',
+    'Smart Link'
+  );
+
+  assert.equal(
     J2S.toSlack('Multiple Links: [Someurl1|http://someurl1.com] links to [Someurl2|http://someurl2.com]\n'),
     'Multiple Links: <http://someurl1.com|Someurl1> links to <http://someurl2.com|Someurl2>\n',
     'Multiple Links'
@@ -222,6 +228,7 @@ test('JIRA to Slack: Check All Formatting', (assert) => {
     'No Format: {noformat}pre text{noformat}\n' +
     'Unnamed Link: [http://someurl.com]\n' +
     'Named Link: [Someurl|http://someurl.com]\n' +
+    'Smart Link: [http://someurl.com|http://someurl.com|smart-link]\n' +
     'Multiple Links: [Someurl1|http://someurl1.com] links to [Someurl2|http://someurl2.com]\n' +
     'Blockquote: \nbq. This is quoted\n' +
     'Color: {color:white}This is white text{color}\n' +
@@ -257,6 +264,7 @@ test('JIRA to Slack: Check All Formatting', (assert) => {
     'No Format: ```pre text```\n' +
     'Unnamed Link: <http://someurl.com>\n' +
     'Named Link: <http://someurl.com|Someurl>\n' +
+    'Smart Link: <http://someurl.com>\n' +
     'Multiple Links: <http://someurl1.com|Someurl1> links to <http://someurl2.com|Someurl2>\n' +
     'Blockquote: \n> This is quoted\n' +
     'Color: This is white text\n' +


### PR DESCRIPTION
When you paste a Jira link into Jira, Jira turns that into a smart link. Here's what that looks like in Jira:

<img width="818" alt="Screen Shot 2020-04-09 at 2 11 18 PM" src="https://user-images.githubusercontent.com/993111/78931837-255b0480-7a6c-11ea-97a0-88026bec3706.png">

And the resulting webhook looks like this:

`"body": "[https://pi-dev-sandbox.jira-dev.com/browse/LIN-2|https://pi-dev-sandbox.jira-dev.com/browse/LIN-2|smart-link]",`

Without smart link detection, that ends up looking like this in Slack:

<img width="529" alt="Screen Shot 2020-04-09 at 2 16 01 PM" src="https://user-images.githubusercontent.com/993111/78932185-b205c280-7a6c-11ea-9e66-796b480bbf14.png">

With this code, it looks like this:

<img width="512" alt="Screen Shot 2020-04-09 at 2 16 38 PM" src="https://user-images.githubusercontent.com/993111/78932228-c2b63880-7a6c-11ea-8122-a2a3a167784f.png">
