### PR TITLE
Moved Smart Links replace before Strikethrough

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,9 @@ function toSlack (jiraMD) {
     // Subscript
     .replace(/~([^~]*)~/g, '_$1')
 
+    // Smart Links
+    .replace(/\[([^[\]|]+?)\|([^[\]|]+?)\|(smart-link)\]/g, '<$1>')
+
     // Strikethrough
     .replace(/((\W)-|(^)-)( *)(\S.*?\S)( *)(-(\W)|-($))/gm, '$2$3$4~$5~$6$8')
 
@@ -71,9 +74,6 @@ function toSlack (jiraMD) {
 
     // Named Links
     .replace(/\[([^[\]|]+?)\|([^[\]|]+?)\]/g, '<$2|$1>')
-
-    // Smart Links
-    .replace(/\[([^[\]|]+?)\|([^[\]|]+?)\|(smart-link)\]/g, '<$1>')
 
     // Single Paragraph Blockquote
     .replace(/^bq\.\s+/gm, '> ')

--- a/index.js
+++ b/index.js
@@ -57,6 +57,12 @@ function toSlack (jiraMD) {
     // Subscript
     .replace(/~([^~]*)~/g, '_$1')
 
+    // Pre-formatted text
+    .replace(/{noformat}/g, '```')
+
+    // Un-named Links
+    .replace(/\[([^|{}\\^~[\]\s"`]+\.[^|{}\\^~[\]\s"`]+)\]/g, '<$1>')
+
     // Smart Links
     .replace(/\[([^[\]|]+?)\|([^[\]|]+?)\|(smart-link)\]/g, '<$1>')
 
@@ -65,12 +71,6 @@ function toSlack (jiraMD) {
 
     // Code Block
     .replace(/\{code(:([a-z]+))?\}([^]*)\{code\}/gm, '```$2$3```')
-
-    // Pre-formatted text
-    .replace(/{noformat}/g, '```')
-
-    // Un-named Links
-    .replace(/\[([^|{}\\^~[\]\s"`]+\.[^|{}\\^~[\]\s"`]+)\]/g, '<$1>')
 
     // Named Links
     .replace(/\[([^[\]|]+?)\|([^[\]|]+?)\]/g, '<$2|$1>')

--- a/test.js
+++ b/test.js
@@ -195,6 +195,12 @@ test('JIRA to Slack: Check Individual Formatting', (assert) => {
     'Panel'
   );
 
+  assert.equal(
+    J2S.toSlack('GitLab Smart Link: [https://gitlab.com/software/ourproject/-/merge_requests/555|https://gitlab.com/software/ourproject/-/merge_requests/555|smart-link]\n'),
+    'GitLab Smart Link: <https://gitlab.com/software/ourproject/-/merge_requests/555>\n',
+    'GitLab Smart Link'
+  );
+
   assert.end();
 });
 
@@ -229,6 +235,7 @@ test('JIRA to Slack: Check All Formatting', (assert) => {
     'Unnamed Link: [http://someurl.com]\n' +
     'Named Link: [Someurl|http://someurl.com]\n' +
     'Smart Link: [http://someurl.com|http://someurl.com|smart-link]\n' +
+    'GitLab Smart Link: [https://gitlab.com/software/ourproject/-/merge_requests/555|https://gitlab.com/software/ourproject/-/merge_requests/555|smart-link]\n' +
     'Multiple Links: [Someurl1|http://someurl1.com] links to [Someurl2|http://someurl2.com]\n' +
     'Blockquote: \nbq. This is quoted\n' +
     'Color: {color:white}This is white text{color}\n' +
@@ -265,6 +272,7 @@ test('JIRA to Slack: Check All Formatting', (assert) => {
     'Unnamed Link: <http://someurl.com>\n' +
     'Named Link: <http://someurl.com|Someurl>\n' +
     'Smart Link: <http://someurl.com>\n' +
+    'GitLab Smart Link: <https://gitlab.com/software/ourproject/-/merge_requests/555>\n' +
     'Multiple Links: <http://someurl1.com|Someurl1> links to <http://someurl2.com|Someurl2>\n' +
     'Blockquote: \n> This is quoted\n' +
     'Color: This is white text\n' +


### PR DESCRIPTION
Moved Smart Links replace before Strikethrough to prevent issue where Gitlab Smart links to have dashes replaced with tildes.